### PR TITLE
feat: Checking DB Rows to Remove Empty Rooms in Startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ dependencies {
 
     implementation("com.github.Softawii:curupira:v0.3.0")
     implementation("com.github.Softawii:curupira:v0.3.0:all")
-    implementation("com.github.minndevelopment:emoji-java:master-SNAPSHOT")
 }
 
 tasks.register('deploy') {

--- a/src/main/java/com/softawii/capivara/config/SpringConfig.java
+++ b/src/main/java/com/softawii/capivara/config/SpringConfig.java
@@ -1,6 +1,5 @@
 package com.softawii.capivara.config;
 
-import com.softawii.capivara.listeners.events.VoiceEvents;
 import com.softawii.capivara.utils.CapivaraExceptionHandler;
 import com.softawii.curupira.core.Curupira;
 import net.dv8tion.jda.api.JDA;

--- a/src/main/java/com/softawii/capivara/config/SpringConfig.java
+++ b/src/main/java/com/softawii/capivara/config/SpringConfig.java
@@ -62,15 +62,12 @@ public class SpringConfig {
     }
 
     @Bean
-    public JDA jda(VoiceEvents voiceEvents) {
+    public JDA jda() {
         JDA jda;
         try {
             JDABuilder builder = JDABuilder.create(discordToken, GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_VOICE_STATES, GatewayIntent.GUILD_EMOJIS_AND_STICKERS, GatewayIntent.GUILD_PRESENCES);
             builder.setMemberCachePolicy(MemberCachePolicy.ALL);
             builder.enableCache(CacheFlag.EMOJI, CacheFlag.ROLE_TAGS, CacheFlag.MEMBER_OVERRIDES, CacheFlag.STICKER);
-            builder.addEventListeners(
-                    voiceEvents
-            );
             jda = builder.build();
             jda.awaitReady();
         } catch (InterruptedException e) {

--- a/src/main/java/com/softawii/capivara/core/DroneManager.java
+++ b/src/main/java/com/softawii/capivara/core/DroneManager.java
@@ -542,7 +542,7 @@ public class DroneManager {
                 voiceDroneService.destroy(drone.getChannelId());
                 if(text != null) text.delete().submit();
             } catch (KeyNotFoundException e) {
-                // Ok
+                LOGGER.info("Key not found, ignoring...");
             }
         } else {
             Optional<Member> ownerOpt = channel.getMembers().stream().filter(member -> member.getIdLong() == drone.getOwnerId()).findFirst();

--- a/src/main/java/com/softawii/capivara/listeners/events/VoiceEvents.java
+++ b/src/main/java/com/softawii/capivara/listeners/events/VoiceEvents.java
@@ -34,9 +34,9 @@ public class VoiceEvents extends ListenerAdapter {
         this.voiceManager = voiceManager;
         this.droneManager = droneManager;
         this.jda = jda;
-        this.jda.addEventListener(this);
         this.droneManager.checkEmptyDrones();
         this.voiceManager.checkRemovedHives();
+        this.jda.addEventListener(this);
     }
 
     //region Voice Events

--- a/src/main/java/com/softawii/capivara/listeners/events/VoiceEvents.java
+++ b/src/main/java/com/softawii/capivara/listeners/events/VoiceEvents.java
@@ -4,6 +4,7 @@ import com.softawii.capivara.core.DroneManager;
 import com.softawii.capivara.core.VoiceManager;
 import com.softawii.capivara.entity.VoiceHive;
 import com.softawii.capivara.exceptions.KeyNotFoundException;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.Category;
@@ -27,10 +28,15 @@ public class VoiceEvents extends ListenerAdapter {
     private final DroneManager droneManager;
 
     private final Logger LOGGER = LogManager.getLogger(VoiceEvents.class);
+    private final JDA    jda;
 
-    public VoiceEvents(VoiceManager voiceManager, DroneManager droneManager) {
+    public VoiceEvents(JDA jda, VoiceManager voiceManager, DroneManager droneManager) {
         this.voiceManager = voiceManager;
         this.droneManager = droneManager;
+        this.jda = jda;
+        this.jda.addEventListener(this);
+        this.droneManager.checkEmptyDrones();
+        this.voiceManager.checkRemovedHives();
     }
 
     //region Voice Events

--- a/src/main/java/com/softawii/capivara/repository/VoiceDroneRepository.java
+++ b/src/main/java/com/softawii/capivara/repository/VoiceDroneRepository.java
@@ -3,8 +3,6 @@ package com.softawii.capivara.repository;
 import com.softawii.capivara.entity.VoiceDrone;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface VoiceDroneRepository extends JpaRepository<VoiceDrone, Long> {
 
     VoiceDrone findByChatId(Long chatId);

--- a/src/main/java/com/softawii/capivara/repository/VoiceDroneRepository.java
+++ b/src/main/java/com/softawii/capivara/repository/VoiceDroneRepository.java
@@ -3,6 +3,8 @@ package com.softawii.capivara.repository;
 import com.softawii.capivara.entity.VoiceDrone;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface VoiceDroneRepository extends JpaRepository<VoiceDrone, Long> {
 
     VoiceDrone findByChatId(Long chatId);

--- a/src/main/java/com/softawii/capivara/services/VoiceDroneService.java
+++ b/src/main/java/com/softawii/capivara/services/VoiceDroneService.java
@@ -3,10 +3,11 @@ package com.softawii.capivara.services;
 import com.softawii.capivara.entity.VoiceDrone;
 import com.softawii.capivara.exceptions.KeyNotFoundException;
 import com.softawii.capivara.repository.VoiceDroneRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import javax.management.openmbean.KeyAlreadyExistsException;
-import java.util.List;
 
 @Service
 public class VoiceDroneService {
@@ -44,7 +45,7 @@ public class VoiceDroneService {
         return voiceDroneRepository.findByChatId(snowflakeId);
     }
 
-    public List<VoiceDrone> findAll() {
-        return voiceDroneRepository.findAll();
+    public Page<VoiceDrone> findAll(Pageable request) {
+        return voiceDroneRepository.findAll(request);
     }
 }

--- a/src/main/java/com/softawii/capivara/services/VoiceDroneService.java
+++ b/src/main/java/com/softawii/capivara/services/VoiceDroneService.java
@@ -6,6 +6,7 @@ import com.softawii.capivara.repository.VoiceDroneRepository;
 import org.springframework.stereotype.Service;
 
 import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.List;
 
 @Service
 public class VoiceDroneService {
@@ -41,5 +42,9 @@ public class VoiceDroneService {
 
     public VoiceDrone findByChatId(Long snowflakeId) throws KeyNotFoundException {
         return voiceDroneRepository.findByChatId(snowflakeId);
+    }
+
+    public List<VoiceDrone> findAll() {
+        return voiceDroneRepository.findAll();
     }
 }

--- a/src/main/java/com/softawii/capivara/services/VoiceHiveService.java
+++ b/src/main/java/com/softawii/capivara/services/VoiceHiveService.java
@@ -4,6 +4,8 @@ import com.softawii.capivara.entity.VoiceHive;
 import com.softawii.capivara.exceptions.ExistingDynamicCategoryException;
 import com.softawii.capivara.exceptions.KeyNotFoundException;
 import com.softawii.capivara.repository.VoiceHiveRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -49,7 +51,7 @@ public class VoiceHiveService {
         return voiceHive.orElseThrow(KeyNotFoundException::new);
     }
 
-    public List<VoiceHive> findAll() {
-        return voiceHiveRepository.findAll();
+    public Page<VoiceHive> findAll(Pageable request) {
+        return voiceHiveRepository.findAll(request);
     }
 }

--- a/src/main/java/com/softawii/capivara/services/VoiceHiveService.java
+++ b/src/main/java/com/softawii/capivara/services/VoiceHiveService.java
@@ -48,4 +48,8 @@ public class VoiceHiveService {
         Optional<VoiceHive> voiceHive = voiceHiveRepository.findById(SnowflakeId);
         return voiceHive.orElseThrow(KeyNotFoundException::new);
     }
+
+    public List<VoiceHive> findAll() {
+        return voiceHiveRepository.findAll();
+    }
 }


### PR DESCRIPTION
**Implementação:
- Dependência do JDA com o VoiceEvents foi invertido (VoiceEvents recebe o JDA instanciado e faz o tratamento em cima dele) 
- Quando o VoiceEvents é iniciado ele executa rotinas de Check de Drones e Hives

Testes:
1. Criei uma Hive

![image](https://github.com/Softawii/capivara/assets/49878392/0a7d5b05-5c9b-45da-a723-47b8f70ef5a2)

2. Criei um Canal Temporário e Desliguei o Bot

![image](https://github.com/Softawii/capivara/assets/49878392/79332fbb-8d28-4a39-bca4-4585158d781d)

3. Sala continua criada:

![image](https://github.com/Softawii/capivara/assets/49878392/faccc9f2-9927-4dbc-8065-affcb399ba11)

4. Ao iniciar o bot deleta automaticamente

![image](https://github.com/Softawii/capivara/assets/49878392/cb63e321-2067-44f7-b368-3791c5a89594)

```log4j
2023-10-27 21:23:43.952  INFO [           main] c.s.c.c.DroneManager                     : Checking to remove drone: 1167619428997922816
2023-10-27 21:23:43.973  INFO [           main] c.s.c.c.VoiceManager                     : Checking if hive is still valid: 1167302305549406259
2023-10-27 21:23:43.973  INFO [           main] c.s.c.c.VoiceManager                     : Checking if hive is still valid: 1167619461063381053
2023-10-27 21:23:43.973  INFO [           main] c.s.c.c.VoiceManager                     : Deleting removed hive 2: 1167619461063381053
```




