### PR TITLE
bugfix: panel not created when user does not have nickname

### DIFF
--- a/src/main/java/com/softawii/capivara/core/DroneManager.java
+++ b/src/main/java/com/softawii/capivara/core/DroneManager.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Component;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -325,7 +326,9 @@ public class DroneManager {
         builder.setTitle("⚙️ Control Panel - " + voiceChannel.getName());
         builder.setDescription("Here, you can control your private voiceChannel.");
         // Fields to Show
-        builder.addField("Owner", voiceChannel.getGuild().getMemberById(drone.getOwnerId()).getNickname(), true);
+        Member ownerMember = voiceChannel.getGuild().getMemberById(drone.getOwnerId());
+        String owner = Objects.requireNonNullElse(ownerMember.getNickname(), ownerMember.getEffectiveName());
+        builder.addField("Owner", owner, true);
         builder.addField("User Limit", voiceChannel.getUserLimit() == 0 ? "No Limits" : String.valueOf(voiceChannel.getUserLimit()), true);
         builder.addField("Visible", isVisible(voiceChannel) ? "Yes" : "No", true);
         builder.addField("Connectable", canConnect(voiceChannel) ? "Yes" : "No", true);


### PR DESCRIPTION
```java
2023-12-12 23:25:07.474 ERROR [inWS-ReadThread] c.s.c.l.e.VoiceEvents                    : Error on onGenericPermissionOverride
java.lang.IllegalArgumentException: Value may not be null
        at net.dv8tion.jda.internal.utils.Checks.notNull(Checks.java:83) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.api.EmbedBuilder.addField(EmbedBuilder.java:850) ~[CapivaraBot.jar:?]
        at com.softawii.capivara.core.DroneManager.createControlPanel(DroneManager.java:328) ~[CapivaraBot.jar:?]
        at com.softawii.capivara.core.DroneManager.createControlPanel(DroneManager.java:317) ~[CapivaraBot.jar:?]
        at com.softawii.capivara.core.DroneManager.createControlPanel(DroneManager.java:309) ~[CapivaraBot.jar:?]
        at com.softawii.capivara.listeners.events.VoiceEvents.onGenericPermissionOverride(VoiceEvents.java:156) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.api.hooks.ListenerAdapter.onEvent(ListenerAdapter.java:446) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.api.hooks.InterfacedEventManager.handle(InterfacedEventManager.java:96) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.hooks.EventManagerProxy.handleInternally(EventManagerProxy.java:88) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.hooks.EventManagerProxy.handle(EventManagerProxy.java:70) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.JDAImpl.handleEvent(JDAImpl.java:177) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.handle.ChannelUpdateHandler.lambda$applyPermissions$0(ChannelUpdateHandler.java:261) ~[CapivaraBot.jar:?]
        at gnu.trove.map.hash.TLongObjectHashMap.forEachValue(TLongObjectHashMap.java:402) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.handle.ChannelUpdateHandler.applyPermissions(ChannelUpdateHandler.java:258) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.handle.ChannelUpdateHandler.handleInternally(ChannelUpdateHandler.java:179) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.handle.SocketHandler.handle(SocketHandler.java:39) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.requests.WebSocketClient.onDispatch(WebSocketClient.java:1015) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.requests.WebSocketClient.onEvent(WebSocketClient.java:901) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.requests.WebSocketClient.handleEvent(WebSocketClient.java:879) ~[CapivaraBot.jar:?]
        at net.dv8tion.jda.internal.requests.WebSocketClient.onBinaryMessage(WebSocketClient.java:1054) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ListenerManager.callOnBinaryMessage(ListenerManager.java:385) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ReadingThread.callOnBinaryMessage(ReadingThread.java:276) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ReadingThread.handleBinaryFrame(ReadingThread.java:996) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:755) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64) ~[CapivaraBot.jar:?]
        at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45) ~[CapivaraBot.jar:?]
```